### PR TITLE
设置链接前先备份~/.vimrc.bundles

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,8 +13,8 @@ lnif() {
 
 echo "Step1: backing up current vim config"
 today=`date +%Y%m%d`
-for i in $HOME/.vim $HOME/.vimrc $HOME/.gvimrc; do [ -e $i ] && [ ! -L $i ] && mv $i $i.$today; done
-for i in $HOME/.vim $HOME/.vimrc $HOME/.gvimrc; do [ -L $i ] && unlink $i ; done
+for i in $HOME/.vim $HOME/.vimrc $HOME/.gvimrc $HOME/.vimrc.bundles; do [ -e $i ] && [ ! -L $i ] && mv $i $i.$today; done
+for i in $HOME/.vim $HOME/.vimrc $HOME/.gvimrc $HOME/.vimrc.bundles; do [ -L $i ] && unlink $i ; done
 
 
 echo "Step2: setting up symlinks"
@@ -39,7 +39,7 @@ export SHELL=$system_shell
 
 
 echo "Step5: compile YouCompleteMe"
-echo "It will take a long time, juse be patient!"
+echo "It will take a long time, just be patient!"
 echo "If error,you need to compile it yourself"
 echo "cd $CURRENT_DIR/bundle/YouCompleteMe/ && bash -x install.sh --clang-completer"
 cd $CURRENT_DIR/bundle/YouCompleteMe/


### PR DESCRIPTION
注意到项目的插件配置已转移到`vimrc.bundles`文件， 所以`install.sh`备份的时候也应该把`~/.vimrc.bundles`加上  :-)
