### PR TITLE
解决基于GTK+桌面环境下的gvim字体显示问题

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -469,6 +469,9 @@ nnoremap <buffer> <F10> :exec '!python' shellescape(@%, 1)<cr>
 " Set extra options when running in GUI mode
 if has("gui_running")
     set guifont=Monaco:h14
+    if has("gui_gtk2")   "GTK2
+        set guifont=Monaco\ 12, Monospace\ 12
+    endif
     set guioptions-=T
     set guioptions+=e
     set guioptions-=r


### PR DESCRIPTION
在ubuntu中使用之前的配置，gvim字体一直不能正常显示，今天在vim中查了一下`:help guifont`，发现Mac OSX中和基于GTK+的桌面设置gvim字体的语句有所不同。

 现在添加了检查语句，确保在GTK+ 2 桌面下也能正常显示，在Mac OSX下，显示不受影响.
