### PR TITLE
添加系统clang检测语句, fix #26

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,7 +43,12 @@ echo "It will take a long time, just be patient!"
 echo "If error,you need to compile it yourself"
 echo "cd $CURRENT_DIR/bundle/YouCompleteMe/ && bash -x install.sh --clang-completer"
 cd $CURRENT_DIR/bundle/YouCompleteMe/
-bash -x install.sh --clang-completer
+if [ `whereis clang` ]   # check system clang
+then
+    bash -x install.sh --clang-completer --system-libclang   # use system clang
+else
+    bash -x install.sh --clang-completer
+fi
 
 #vim bk and undo dir
 if [ ! -d /tmp/vimbk ]


### PR DESCRIPTION
在系统已安装clang的情况下，按照@OwenJia的方法编译YCM，确实可行，现添加检测语句，如果系统搜索路径中已经安装clang，则使用系统clang.  

PS: 编译过程中下载那个clang，速度真心慢，有的时候需要等好几个小时都搞不定...
