### PR TITLE
增加pydoc,Drawit,VisIncr,Vis几个插件备选

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -504,16 +504,16 @@ Bundle 'Glench/Vim-Jinja2-Syntax'
 " nnoremap <F10> :QuickRun<cr>
 "
 " pydoc
-Bundle 'pydoc.vim'
+"Bundle 'pydoc.vim'
 
 " 画图
-Bundle 'DrawIt'
+"Bundle 'DrawIt'
 
 " 纵向编辑
-Bundle 'VisIncr'
+"Bundle 'VisIncr'
 
 " 指定范围批量替换
-Bundle 'vis'
+"Bundle 'vis'
 
 
 "------------------------------------------- end of configs --------------------------------------------


### PR DESCRIPTION
赞，又跟着折腾了一把。我在centos6上编译vim7.4+python2.7-dev+Youcomplate真的是折腾啊。

增加了我几个常用的插件:
- pydoc: 偶尔查看下函数参数很方便
- DrawIt: 很常用，经常在代码中插入图形注释
- VisIncr 和 vis 偶尔用用，但一般能节省不少时间。

这几个插件都很轻量，希望能加到备选名单里。

因为之前没有同步上游库，所以commit记录乱掉了，实际就更改了一个文件。
