### PR TITLE
remove `set nocompatible`

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -8,8 +8,6 @@
 "package dependence:  ctags
 "python dependence:   pep8, pyflake
 
-"非兼容vi模式。去掉讨厌的有关vi一致性模式，避免以前版本的一些bug和局限
-set nocompatible
 " configure Vundle
 filetype off " required! turn off
 set rtp+=~/.vim/bundle/vundle/


### PR DESCRIPTION
这个没有必要，因为只要 vimrc 存在默认就是开启的，
可以看[文档](http://vimdoc.sourceforge.net/htmldoc/options.html#'nocompatible')
或者直接在 vim 里面按 :help 'cp'

我已经在自己的电脑上试过了，没有任何问题。
我第一次是在这里看到的：
https://github.com/thoughtbot/dotfiles/commit/e088612438877d4584c25f14a65daefe62df20d6