### PR TITLE
vimrc添加几个快捷键

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -70,16 +70,16 @@ set shortmess=atI       " 启动的时候不显示那个援助索马里儿童的
 " 取消备份。 视情况自己改
 set nobackup
 " 关闭交换文件
-set noswapfile
+" set noswapfile
 
 
 "create undo file
-if has('persistent_undo')
-  set undolevels=1000         " How many undos
-  set undoreload=10000        " number of lines to save for undo
-  set undofile                " So is persistent undo ...
-  set undodir=/tmp/vimundo/
-endif
+" if has('persistent_undo')
+"   set undolevels=1000         " How many undos
+"   set undoreload=10000        " number of lines to save for undo
+"   set undofile                " So is persistent undo ...
+"   set undodir=/tmp/vimundo/
+" endif
 
 set wildignore=*.swp,*.bak,*.pyc,*.class,.svn
 " 突出显示当前行等
@@ -347,7 +347,7 @@ noremap L $
 
 "Map ; to : and save a million keystrokes
 " ex mode commands made easy 用于快速进入命令行
-nnoremap ; :
+" nnoremap ; :
 
 
 " 命令行模式增强，ctrl - a到行首， -e 到行尾
@@ -531,6 +531,15 @@ autocmd FileType ruby set tabstop=2 shiftwidth=2 softtabstop=2 expandtab ai
 autocmd BufRead,BufNew *.md,*.mkd,*.markdown  set filetype=markdown.mkd
 
 
+" 设置C和C++的Tab键为8
+function Tab8()
+	set tabstop=8
+	set shiftwidth=8
+endfunc
+
+autocmd FileType c exec "call Tab8()"
+autocmd FileType cpp exec "call Tab8()"
+
 " 保存python文件时删除多余空格
 fun! <SID>StripTrailingWhitespaces()
     let l = line(".")
@@ -542,11 +551,15 @@ autocmd FileType c,cpp,java,go,php,javascript,puppet,python,rust,twig,xml,yml,pe
 
 
 " 定义函数AutoSetFileHead，自动插入文件头
-autocmd BufNewFile *.sh,*.py exec ":call AutoSetFileHead()"
+autocmd BufNewFile *.sh,*.py,*.c,*.cpp exec ":call AutoSetFileHead()"
 function! AutoSetFileHead()
     "如果文件类型为.sh文件
     if &filetype == 'sh'
-        call setline(1, "\#!/bin/bash")
+        call setline(1,"#!/bin/bash")
+        call setline(2,"#History:")
+        call setline(3,"#   Michael	".strftime("%b,%d,%Y"))
+        call setline(4,"#Program:")
+        call setline(5,"#")
     endif
 
     "如果文件类型为python
@@ -555,9 +568,37 @@ function! AutoSetFileHead()
         call append(1, "\# encoding: utf-8")
     endif
 
-    normal G
-    normal o
-    normal o
+    "如果文件类型为c
+    if &filetype == "c"
+        call setline(1,"#include<apue.h>")
+        call append(line("."),"")
+        call append(line(".")+1,"int main(int argc,char *argv[])")
+        call append(line(".")+2,"{")
+        call append(line(".")+3,"	return 0;")
+        call append(line(".")+4,"}")
+    endif
+
+    "如果文件类型为c++
+    if &filetype == "cpp"
+        call setline(1,"#include<iostream>")
+        call append(line("."),"using namespace std;")
+        call append(line(".")+1,"int main()")
+        call append(line(".")+2,"{")
+        call append(line(".")+3,"	return 0;")
+        call append(line(".")+4,"}")
+    endif
+
+
+    if &filetype == 'python' || &filetype == 'sh'
+        normal G
+        normal o
+        normal o
+    elseif &filetype == 'c' || &filetype == 'cpp'
+        normal G
+        normal k
+        normal O
+    endif
+
 endfunc
 
 
@@ -604,6 +645,7 @@ endif
 set background=dark
 set t_Co=256
 colorscheme solarized
+" colorscheme molokai
 " colorscheme Tomorrow-Night
 " colorscheme Tomorrow-Night-Bright
 " colorscheme desert
@@ -624,3 +666,12 @@ highlight clear SpellRare
 highlight SpellRare term=underline cterm=underline
 highlight clear SpellLocal
 highlight SpellLocal term=underline cterm=underline
+
+" change word to uppercase, I love this very much
+inoremap <C-y> <esc>gUiwea
+
+" 将%:h映射为%%，%:h的功能是显示当前缓冲区文件的绝对路径
+cnoremap <expr> %% getcmdtype() == ':' ? expand('%:h').'/' : '%%'
+
+" 将<F10>按键映射成打开或者关闭paste选项的开关
+set pastetoggle=<F10>


### PR DESCRIPTION
主要想提交的是vimrc文件的669 - 677行，三个小技巧！

1. 插入模式下ctrl + y键将单词一键变成大写。
2. 命令模式下，%%显示缓冲区文件的路径。
3. F10为插入模式下paste选项的开关（关闭自动缩进等）。