### PR TITLE
修正某些情况下回车打印乱码|按<tab>报错

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -265,8 +265,8 @@ set wildignore=*.o,*~,*.pyc,*.class
 
 "离开插入模式后自动关闭预览窗口
 autocmd InsertLeave * if pumvisible() == 0|pclose|endif
-"回车即选中当前项
-inoremap <expr> <CR>       pumvisible() ? "\<C-y>" : "\<CR>"
+"回车即选中当前项(在gentoo中会冲突，回车会打印字符串pumvisible() ? "\" : "\)
+"inoremap <expr> <CR>       pumvisible() ? "\<C-y>" : "\<CR>"
 
 "上下左右键的行为 会显示其他信息
 inoremap <expr> <Down>     pumvisible() ? "\<C-n>" : "\<Down>"

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -123,6 +123,8 @@ let g:ycm_filetype_blacklist = {
 Bundle 'SirVer/ultisnips'
 " Snippets are separated from the engine. Add this if you want them:
 Bundle 'honza/vim-snippets'
+" 在gentoo中， 需要而外安装最新版的superTab确保在按<tab>键的时候不报错
+Bundle 'ervandew/supertab'
 
 let g:UltiSnipsExpandTrigger       = "<tab>"
 let g:UltiSnipsJumpForwardTrigger  = "<tab>"


### PR DESCRIPTION
ultisnip需要最新的superTab，否则在某些系统中按table键会报错

顺带回车即选中当前项 (在gentoo中会冲突，回车会打印字符串pumvisible() ? "\" : "\)

默认注释掉吧， 有需求的话自行解除注释。