### PR TITLE
复制选中区到剪切板

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -616,3 +616,12 @@ highlight clear SpellRare
 highlight SpellRare term=underline cterm=underline
 highlight clear SpellLocal
 highlight SpellLocal term=underline cterm=underline
+
+" share system clipboard
+if has('clipboard')
+        if has('unnamedplus')  " When possible use + register for copy-paste
+            set clipboard=unnamed,unnamedplus
+        else         " On mac and Windows, use * register for copy-paste
+            set clipboard=unnamed
+        endif
+endif


### PR DESCRIPTION
刚才看到了更新 我是在用的这一个 感觉更好用一切 可以是因为不用 `"+p` 来粘贴的原因吧。
直接 y就是复制到系统粘贴板 p是粘贴。