### PR TITLE
Javascript indentation should be 2 spaces

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -552,7 +552,7 @@ nmap <silent> <leader>sv :so $MYVIMRC<CR>
 
 " 具体编辑文件类型的一般设置，比如不要 tab 等
 autocmd FileType python set tabstop=4 shiftwidth=4 expandtab ai
-autocmd FileType ruby set tabstop=2 shiftwidth=2 softtabstop=2 expandtab ai
+autocmd FileType ruby,javascript,html,css,xml set tabstop=2 shiftwidth=2 softtabstop=2 expandtab ai
 autocmd BufRead,BufNewFile *.md,*.mkd,*.markdown set filetype=markdown.mkd
 autocmd BufRead,BufNewFile *.part set filetype=html
 " disable showmatch when use > in php


### PR DESCRIPTION
According to Javascript Style Guide (see https://github.com/airbnb/javascript), files like `html`, `javascript`, `css`, `xml` should keep their indentation to be 2 spaces.

so i think this modification is reasonable and helpful for k-vim's users.