### PR TITLE
为 Javascript 补全插件 tern_for_vim增加必要的说明

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -206,8 +206,9 @@ if count(g:bundle_groups, 'javascript')
     Plug 'othree/javascript-libraries-syntax.vim'
     let g:used_javascript_libs = 'jquery,underscore,backbone'
 
-    " for javascript 自动补全,配合YCM,需要安装nodejs&npm  see
-    " https://github.com/marijnh/tern_for_vim
+    " for javascript 自动补全, 配合YCM, 需要安装全局环境的（非nvm中) node.js&npm
+    " 安装完成后还需要在 bundle/tern_for_vim 下执行 npm install 安装依赖
+    " see https://github.com/marijnh/tern_for_vim
     " Plug 'marijnh/tern_for_vim'
 endif
 


### PR DESCRIPTION
tern_for_vim 不接受 nvm 中任何版本的 node.js，需要全局的 node.js。
`:PluginInstall` 安装完成后，需要在 tern_for_vim 的目录下执行局部的 package.json 中的依赖的安装后，补全才能生效。