### PR TITLE
Hardcore ignore whole entire bundle folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-bundle/*
+bundle
 *.pyc
 *.bak
 *.bk


### PR DESCRIPTION
Git won't track empty folder, but when it filled with plugins, local git will alway be `Changes not staged for commit` state, so it's better to ignore it...