### PR TITLE
映射了一些打印字符

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -346,6 +346,7 @@ function! HideNumber()
 endfunc
 nnoremap <F2> :call HideNumber()<CR>
 " F3 显示可打印字符开关
+set listchars=tab:›-,trail:•,extends:#,nbsp:f,eol:$
 nnoremap <F3> :set list! list?<CR>
 " F4 换行开关
 nnoremap <F4> :set wrap! wrap?<CR>


### PR DESCRIPTION
当开启显示打印字符时，让某些字符为一些特殊格式！详见[:help listchars](http://vimdoc.sourceforge.net/htmldoc/options.html#'listchars')

在我的电脑上，显示效果是这样！

![2](https://cloud.githubusercontent.com/assets/11701497/14196752/e5a1c336-f7f9-11e5-865f-118f736163d6.jpg)


