### PR TITLE
屏幕左右滑动的快捷键

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -391,6 +391,8 @@ map <C-l> <C-W>l
 " 屏幕左右滑动的快捷键
 map <C-Right> zl
 map <C-Left> zh
+map <S-Right> zL
+map <S-Left> zH
 
 
 " http://stackoverflow.com/questions/13194428/is-better-way-to-zoom-windows-in-vim-than-zoomwin

--- a/vimrc
+++ b/vimrc
@@ -388,6 +388,11 @@ map <C-h> <C-W>h
 map <C-l> <C-W>l
 
 
+" 屏幕左右滑动的快捷键
+map <C-Right> zl
+map <C-Left> zh
+
+
 " http://stackoverflow.com/questions/13194428/is-better-way-to-zoom-windows-in-vim-than-zoomwin
 " Zoom / Restore window.
 function! s:ZoomToggle() abort


### PR DESCRIPTION
有时候代码太长，屏幕一行占满了，开启了换行以后，感觉好乱！我知道代码要准守80char的规范，但是看别人的代码不一定是80char啊！如果用原生的`zl`，`zh`，按起来太别扭了，不能持续按！

所以我重新映射了一下，这个需求@wklken说是小众需求[#214](https://github.com/wklken/k-vim/pull/214)，所以我就没有映射到home row上面，映射到了上下左右方向键上（Vimer们使用上下左右方向键的频率应该很低吧）!

目前的结果是这样的`<C-Left>`和`<C-Right>`为让屏幕左右小幅度移动，`<S-Left>`和`<S-Right>`为让屏幕左右大幅度移动！
