### PR TITLE
add colorscheme onedark && use 24-bit color

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -660,15 +660,30 @@ if has("gui_running")
 endif
 
 
-
 " theme主题
 set background=dark
 set t_Co=256
 
+" Use 24-bit (true-color) mode in Vim/Neovim when outside tmux.
+" If you're using tmux version 2.2 or later, you can remove the outermost $TMUX check and use tmux's 24-bit color support
+" (see < http://sunaku.github.io/tmux-24bit-color.html#usage > for more information.)
+if (empty($TMUX))
+  if (has("nvim"))
+    " For Neovim 0.1.3 and 0.1.4 < https://github.com/neovim/neovim/pull/2198 >
+    let $NVIM_TUI_ENABLE_TRUE_COLOR=1
+  endif
+  " For Neovim > 0.1.5 and Vim > patch 7.4.1799 < https://github.com/vim/vim/commit/61be73bb0f965a895bfb064ea3e55476ac175162 >
+  " Based on Vim patch 7.4.1770 (`guicolors` option) < https://github.com/vim/vim/commit/8a633e3427b47286869aa4b96f2bfc1fe65b25cd >
+  " < https://github.com/neovim/neovim/wiki/Following-HEAD#20160511 >
+  if (has("termguicolors"))
+    set termguicolors
+  endif
+endif
+
 colorscheme solarized
 " colorscheme molokai
 " colorscheme desert
-
+" colorscheme onedark
 
 " 设置标记一列的背景颜色和数字一行颜色一致
 hi! link SignColumn   LineNr

--- a/vimrc
+++ b/vimrc
@@ -680,10 +680,10 @@ if (empty($TMUX))
   endif
 endif
 
-colorscheme solarized
+" colorscheme solarized
 " colorscheme molokai
 " colorscheme desert
-" colorscheme onedark
+colorscheme onedark
 
 " 设置标记一列的背景颜色和数字一行颜色一致
 hi! link SignColumn   LineNr

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -17,7 +17,7 @@ filetype off " required! turn off
 " inspired by spf13, 自定义需要的插件集合
 if !exists('g:bundle_groups')
     " let g:bundle_groups=['python', 'javascript', 'markdown', 'html', 'css', 'tmux', 'beta', 'json', 'nginx', 'golang', 'ruby', 'less', 'php', 'coffeescript']
-    let g:bundle_groups=['python', 'javascript', 'markdown', 'html', 'css', 'tmux', 'beta']
+    let g:bundle_groups=['python', 'javascript', 'markdown', 'html', 'css', 'tmux', 'beta', 'golang']
 endif
 
 " ----------------------------------------------------------------------------
@@ -601,7 +601,7 @@ call plug#end()
     let g:airline_right_alt_sep = '❮'
     let g:airline_symbols.linenr = '¶'
     let g:airline_symbols.branch = '⎇'
-    " let g:airline_theme = 'onedark'
+    let g:airline_theme = 'onedark'
     " 是否打开tabline
     " let g:airline#extensions#tabline#enabled = 1
 " }}}

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -135,7 +135,8 @@ Plug 'altercation/vim-colors-solarized'
 " molokai
 " 主题 molokai
 Plug 'tomasr/molokai'
-
+" 主题 onedark
+Plug 'joshdick/onedark.vim'
 
 " nav
 " nerdtree nerdtreetabs
@@ -600,6 +601,7 @@ call plug#end()
     let g:airline_right_alt_sep = '❮'
     let g:airline_symbols.linenr = '¶'
     let g:airline_symbols.branch = '⎇'
+    " let g:airline_theme = 'onedark'
     " 是否打开tabline
     " let g:airline#extensions#tabline#enabled = 1
 " }}}
@@ -650,6 +652,13 @@ call plug#end()
     let g:molokai_original = 1
     let g:rehash256 = 1
 " }}}
+
+" onedark {{{
+    " 使用16-color mode
+    " let g:onedark_termcolors=16
+    " 使用256-color mode
+    " let g:onedark_termcolors=256
+"}}}
 
 " ################### 快速导航 ###################
 


### PR DESCRIPTION
1. 添加onedark主题, 默认关闭
2. 如果终端支持24-bit color的话, 使用24-bit color, 如果不支持的话, 可以选择16-color或者256color
3. 添加airline的onedark主题选项