### PR TITLE
支持Angular和Typescript

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -563,7 +563,7 @@ nmap <silent> <leader>sv :so $MYVIMRC<CR>
 
 " 具体编辑文件类型的一般设置，比如不要 tab 等
 autocmd FileType python set tabstop=4 shiftwidth=4 expandtab ai
-autocmd FileType ruby,javascript,html,css,xml set tabstop=2 shiftwidth=2 softtabstop=2 expandtab ai
+autocmd FileType ruby,javascript,html,css,json,scss,xml set tabstop=2 shiftwidth=2 softtabstop=2 expandtab ai
 autocmd BufRead,BufNewFile *.md,*.mkd,*.markdown set filetype=markdown.mkd
 autocmd BufRead,BufNewFile *.part set filetype=html
 " disable showmatch when use > in php

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -225,6 +225,10 @@ if count(g:bundle_groups, 'javascript')
     " Plug 'marijnh/tern_for_vim', {'do': 'npm install'}
 endif
 
+if count(g:bundle_groups, 'typescript')
+    Plug 'leafgarland/typescript-vim'
+endif
+
 
 if count(g:bundle_groups, 'coffeescript')
     Plug 'kchmck/vim-coffee-script'
@@ -308,8 +312,11 @@ call plug#end()
     " let g:syntastic_python_checkers=['pylint'] " 使用pyflakes,速度比pylint快
     " let g:syntastic_python_pylint_args='--disable=C0111,R0903,C0301'
 
+    " if ts
+    " let g:syntastic_typescript_checkers = ['tsc', 'tslint']
+
     " if js
-    " let g:syntastic_javascript_checkers = ['jsl', 'jshint']
+    " let g:syntastic_javascript_checkers = ['jsl', 'jshint', 'eslint']
     " let g:syntastic_html_checkers=['tidy', 'jshint']
 
     " to see error location list


### PR DESCRIPTION

## Details 

- SCSS和JSON的Tab space changed from 4 -> 2.
- 新增加 Plugin leafgarland/typescript-vim for typescript.
- Add tslint to typescript checkers, this will support Angular CLI.
- Add eslint to javascript checkers.