### PR TITLE
fix Mac's default vim NERDTree have ^G

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -738,6 +738,8 @@ endif
     " s/v 分屏打开文件
     let g:NERDTreeMapOpenSplit = 's'
     let g:NERDTreeMapOpenVSplit = 'v'
+    " fix Nerdtree ^G before folder and file names OSX terminal vim
+    let g:NERDTreeNodeDelimiter = "\u00a0"
 
 
     " nerdtreetabs


### PR DESCRIPTION
修复mac默认vim使用NERDTree会有侧边栏带`^G`的问题 [ref](https://stackoverflow.com/questions/53657545/nerdtree-g-before-folder-and-file-names-osx-terminal-vim)