### PR TITLE
fix snips Copyright email address

### DIFF
--- a/UltiSnips/all.snippets
+++ b/UltiSnips/all.snippets
@@ -1,7 +1,7 @@
 # Global snippets
 
 snippet Copy
-Copyright (c) ${1:`!v g:snips_author`} <${2:`!v g:snips_author_email`}>. All Rights Reserved.
+Copyright (c) ${1:`!v g:snips_author`} <${2:`!v g:snips_email`}>. All Rights Reserved.
 $0
 endsnippet
 


### PR DESCRIPTION
vimsnippets.vim only define the leg g:snips_email = "..".
So we need change the snips_author_email to snips_email