### PR TITLE
Upgrade YCM to python3

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -91,9 +91,9 @@ cd $CURRENT_DIR/bundle/YouCompleteMe/
 git submodule update --init --recursive
 if [ `which clang` ]   # check system clang
 then
-    python install.py --clang-completer --system-libclang   # use system clang
+    python3 install.py --clangd-completer --system-libclang   # use system clang
 else
-    python install.py --clang-completer
+    python3 install.py --clangd-completer
 fi
 
 echo "Install Done!"


### PR DESCRIPTION
YCM has been moved to python3 (check [this](https://github.com/ycm-core/YouCompleteMe#warning-support-for-python-2-has-been-dropped)).

BTW: the README says `./install.py --clangd-completer` instead of `--clang-completer`.